### PR TITLE
advanced API search

### DIFF
--- a/beetsplug/popularity.py
+++ b/beetsplug/popularity.py
@@ -45,6 +45,21 @@ class Popularity(BeetsPlugin):
     def _on_write(self, item, path, tags):
         # query and set popularity value for the item that is to be imported
         self._set_popularity(item, False)
+    
+    # helper functions
+    def _replace_brackets(self, string):
+        # replace all brackets and its content within the Title
+        string = re.sub(r'\(.*?\)', '', string)
+        string = re.sub(r'\[.*?\]', '', string)
+        string = re.sub('\s+', ' ', string).strip()
+        return string
+    def _has_brackets(self, string):
+        # replace true if string contains brackets
+        brackets = ["(", ")", "[", "]"]
+        has_brackets = False
+        if any(bracket in string for bracket in brackets):
+            has_brackets = True
+        return has_brackets
 
     def _set_popularity(self, item, nowrite):
         # query Spotify API

--- a/beetsplug/popularity.py
+++ b/beetsplug/popularity.py
@@ -8,7 +8,8 @@ import requests
 
 
 class Popularity(BeetsPlugin):
-
+    
+# inital functions
     def __init__(self):
         super(Popularity, self).__init__()
         self.item_types = {'popularity': types.INTEGER}
@@ -46,13 +47,14 @@ class Popularity(BeetsPlugin):
         # query and set popularity value for the item that is to be imported
         self._set_popularity(item, False)
     
-    # helper functions
+# helper functions
     def _replace_brackets(self, string):
         # replace all brackets and its content within the Title
         string = re.sub(r'\(.*?\)', '', string)
         string = re.sub(r'\[.*?\]', '', string)
         string = re.sub('\s+', ' ', string).strip()
         return string
+    
     def _has_brackets(self, string):
         # replace true if string contains brackets
         brackets = ["(", ")", "[", "]"]
@@ -60,15 +62,12 @@ class Popularity(BeetsPlugin):
         if any(bracket in string for bracket in brackets):
             has_brackets = True
         return has_brackets
-
-    def _set_popularity(self, item, nowrite):
-        # query Spotify API
-        query = 'artist:"' + item.artist + '" album:"' + item.album + '" track:"' + item.title + '"'
-        #query = item.artist + ' ' + item.album + ' ' + item.title
+    
+# request functions
+    def _try_api_request(self, item, nowrite, query):
         payload = {'q': query, 'order': 'RANKING'}
         #payload = {'q': query, 'type': 'track', 'limit': '1'}
         response = requests.get(self.API_URL, params=payload)
-
         try:
             # raise an exception for bad response status codes
             response.raise_for_status()
@@ -80,24 +79,89 @@ class Popularity(BeetsPlugin):
 
             # raise an exception if the query returned no tracks
             if not tracks:
+                popularity_found = False
                 raise EmptyResponseError()
+            else:
+                popularity_found = True
+                popularity = round(tracks[0]["rank"] / 10000)
+                #popularity = tracks[0]["popularity"]
+                self._log.info(
+                    u'{0.artist} - {0.title}: {1}', item, popularity)
 
-            popularity = round(tracks[0]["rank"] / 10000)
-            #popularity = tracks[0]["popularity"]
-            self._log.info(
-                u'{0.artist} - {0.album} - {0.title}: {1}', item, popularity)
-
-            # store the popularity value as a flexible attribute
-            if not nowrite:
-                item.popularity = popularity
-                item.store()
+                # store the popularity value as a flexible attribute
+                if not nowrite:
+                    item.popularity = popularity
+                    item.store()
 
         except requests.exceptions.HTTPError:
             self._log.warning(u'Bad status code in API response')
         except EmptyResponseError:
             self._log.debug(
                 u'{0.title} - {0.artist} not found', item)
+        return popularity_found;
+    
+    def _api_requests(self, item, nowrite, artiststr, albumstr, titlestr):
+        popularity_found = False
+        # search with explicit tag statement and with album
+        query = 'artist:"' + artiststr + '" album:"' + albumstr + '" track:"' + titlestr + '"'
+        popularity_found = self._try_api_request(item, nowrite, query)
+        if not popularity_found:
+            # search without explicit tag statement and with album
+            query = '"' + artiststr + ' - ' + albumstr + ' - ' + titlestr + '"'
+            popularity_found = self._try_api_request(item, nowrite, query)
+        if not popularity_found:
+            # search with explicit tag statement and without album
+            query = 'artist:"' + artiststr + '" track:"' + titlestr + '"'
+            popularity_found = self._try_api_request(item, nowrite, query)
+        if not popularity_found:
+            # search without explicit tag statement and without album
+            query = '"' + artiststr + ' - ' + titlestr + '"'
+            popularity_found = self._try_api_request(item, nowrite, query)
+        return popularity_found
+    
+    def _set_popularity(self, item, nowrite):
+        # replacing specific minus from musicbrainz with that it can't find anything from the API (compare: http://unicode.scarfboy.com/?s=%E2%80%90 and  http://unicode.scarfboy.com/?s=-)
+        # example: "blink‐182" will be "blink-182"
+        artiststr = item.artist.replace("‐", "-")
+        albumstr = item.album.replace("‐", "-")
+        titlestr = item.title.replace("‐", "-")
 
+        artistseperators = [" feat ", " feat. ", " & ", ", ", " , ", " featuring "]
+        # delete featuring strings out of artist
+        for artistseperator in artistseperators:
+            allartiststr = artiststr.replace(artistseperator, " ")
+        allartiststr = allartiststr.strip()
+
+        popularity_found = False
+
+        # first normal api request
+        popularity_found = self._api_requests(item, nowrite, allartiststr, albumstr, titlestr)
+
+        # without brackets in title:
+        if not popularity_found:
+            # check if title has brackets
+            if self._has_brackets(titlestr):
+                # try it without brackets in title
+                replacedtitle = self._replace_brackets(titlestr)
+                popularity_found =  self._api_requests(item, nowrite, allartiststr, albumstr, replacedtitle)
+
+        # seperate artists:
+        if not popularity_found:
+            # check if there are multiple artists in artist tag
+            seperateartists = re.split("|".join(artistseperators),artiststr)
+            if len(seperateartists) > 1:
+                # try it for each artist with brackets in title
+                for seperateartist in seperateartists:
+                    popularity_found = self._api_requests(item, nowrite, seperateartist, albumstr, titlestr)
+                    if popularity_found:
+                        break
+                # try it for each artist if it has brackets in title
+                if not popularity_found and self._has_brackets(titlestr):
+                    replacedtitle = self._replace_brackets(titlestr)
+                    for seperateartist in seperateartists:
+                        popularity_found = self._api_requests(item, nowrite, seperateartist, albumstr, replacedtitle)
+                        if popularity_found:
+                            break
 
 class EmptyResponseError(Exception):
     pass

--- a/beetsplug/popularity.py
+++ b/beetsplug/popularity.py
@@ -5,7 +5,7 @@ from beets.dbcore import types
 import beets.ui as ui
 import json
 import requests
-
+import re
 
 class Popularity(BeetsPlugin):
     

--- a/beetsplug/popularity.py
+++ b/beetsplug/popularity.py
@@ -6,8 +6,10 @@ import beets.ui as ui
 import json
 import requests
 import re
+import time
 
 class Popularity(BeetsPlugin):
+    apirequests = 0
     
 # inital functions
     def __init__(self):
@@ -68,6 +70,13 @@ class Popularity(BeetsPlugin):
         payload = {'q': query, 'order': 'RANKING'}
         #payload = {'q': query, 'type': 'track', 'limit': '1'}
         response = requests.get(self.API_URL, params=payload)
+        
+        # sleep for 3 seconds if 50 api requests were executed due to deezers api limit that says: "limited to 50 requests / 5 seconds"
+        if self.apirequests == 50:
+            self.apirequests = 0
+            time.sleep(2)
+        self.apirequests += 1
+        
         try:
             # raise an exception for bad response status codes
             response.raise_for_status()


### PR DESCRIPTION
I had a look at the tracks that did not have the popularity stored and determined why they did not match.

Then I defined a query sequence which will be executed one by one and afterwards it checks if it already found the popularity on the deezer API.
### defined query sequence:
1. 'artist:"artist" album:"album" track:"track"'
2. "artist - album - track"
3. 'artist:"artist" track:"track"'
4. "artist - track"

### execution part:
1. This sequence is first executed with the given strings stored in the item
2. if popularity tag wasn't found with (1.) it searches without brackets in the title field
3. if popularity tag wasn't found with (2.) it calls the query sequence foreach artist
4. if popularity tag wasn't found with (3.) it calls the query sequence foreach artist and without brackets in the title field

Also I added a little pause after every 50th api request. More about that [here](#5 )